### PR TITLE
Using BrowserRouter instead of HashRouter

### DIFF
--- a/src/app/frontend/App.js
+++ b/src/app/frontend/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { HashRouter, Switch, Route, Link } from 'react-router-dom';
+import { BrowserRouter, Switch, Route, Link } from 'react-router-dom';
 
 import { Top } from './Top';
 import { UserPage } from './UserPage';
@@ -90,7 +90,7 @@ export function App() {
           <div>Initializing...</div>
         </>
       ) : (
-        <HashRouter>
+        <BrowserRouter basename="/__/front/app">
           <PersoniumAuthProvider>
             <PersoniumBoxProvider>
               <AppHeader />
@@ -114,7 +114,7 @@ export function App() {
               <AppFooter />
             </PersoniumBoxProvider>
           </PersoniumAuthProvider>
-        </HashRouter>
+        </BrowserRouter>
       )}
     </PersoniumConfigProvider>
   );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,8 +29,9 @@ module.exports = {
   devServer: {
     contentBase: `${__dirname}/tools`,
     publicPath: '/__/public/',
+    openPage: '__/front/app',
     historyApiFallback: {
-      rewrites: [{ from: '/', to: '/dev_index.html' }],
+      rewrites: [{ from: /^\/__\/front\/app/, to: '/dev_index.html' }],
     },
   },
 };


### PR DESCRIPTION

Since version 1.7.22, Personium can handle dynamic path of engine script.

This update make it possible to handle BrowserRouter.

![image](https://user-images.githubusercontent.com/4243145/120141881-4bb3a480-c218-11eb-81e4-45806a46d61e.png)
